### PR TITLE
Reject domain sizes non power of2

### DIFF
--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -9,14 +9,12 @@ import (
 	"github.com/crate-crypto/go-proto-danksharding-crypto/internal/utils"
 )
 
-// Domain is a struct definend the domain with respect to which polynomials are evaluated.
-// To wit, we work with polynomials in evaluation form (i.e. we store their via their evaluations at Domain.Cardinality many points).
-// The set of these points is what we call the domain.
-// To enable efficient FFT-based algorithms, these points are chosen as 2^i'th roots of unity and we precomputed and store certain values related to
-// that inside the struct.
+// Domain is a struct defining the set of points that polynomials are evaluated over.
+// To enable efficient FFT-based algorithms, these points are chosen as 2^i'th roots of unity and we precompute and store
+// certain values related to that inside the struct.
 type Domain struct {
 	// Size of the domain as a uint64. This must be a power of 2.
-	// Since the basefield has 2^i'th roots of unity for i<=32, Cardinality is <= 2^32)
+	// Since the base field has 2^i'th roots of unity for i<=32, Cardinality is <= 2^32)
 	Cardinality uint64
 	// Inverse of the size of the domain as
 	// a field element. This is useful for
@@ -171,7 +169,7 @@ func (domain *Domain) EvaluateLagrangePolynomial(poly Polynomial, evalPoint fr.E
 	return outputPoint, err
 }
 
-// evaluateLagratePolynomial is the implementation for [EvaluateLagrangePolynomial].
+// evaluateLagrangePolynomial is the implementation for [EvaluateLagrangePolynomial].
 //
 // It evaluates a Lagrange polynomial at the given point of evaluation and reports whether the given point was among the points of the domain:
 // The input polynomial is given in evaluation form, that is, a list of evaluations at the points in the domain.

--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -136,7 +136,7 @@ func (domain *Domain) ReverseRoots() {
 //
 //   - If point is in the domain (meaning that point is a domain.Cardinality'th root of unity), returns the index of the point in the domain.
 //   - If point is not in the domain, returns -1.
-func (domain Domain) findRootIndex(point fr.Element) int {
+func (domain *Domain) findRootIndex(point fr.Element) int {
 	for i := 0; i < int(domain.Cardinality); i++ {
 		if point.Equal(&domain.Roots[i]) {
 			return i

--- a/internal/kzg/domain_test.go
+++ b/internal/kzg/domain_test.go
@@ -97,7 +97,8 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 	}
 
 	// You need at least 3 evaluations to determine a degree 2 polynomial
-	numEvaluations := 3
+	// Due to restriction of the library, we use 4 points.
+	numEvaluations := 4
 	domain := NewDomain(uint64(numEvaluations))
 
 	// lagrangePoly are the evaluations of the coefficient polynomial over

--- a/internal/kzg/kzg_test.go
+++ b/internal/kzg/kzg_test.go
@@ -54,7 +54,7 @@ func TestBatchVerifySmoke(t *testing.T) {
 
 func TestComputeQuotientPolySmoke(t *testing.T) {
 
-	numEvaluations := 127
+	numEvaluations := 128
 	domain := NewDomain(uint64(numEvaluations))
 
 	polyLagrange := randPoly(t, *domain)


### PR DESCRIPTION
Proposed change: NewDomain should panic if the passed argument is not a power of 2.
I raised a related issue with https://github.com/ethereum/c-kzg-4844/issues/226

The semantics for the case where the domain size is not a power of 2 is not documented; there are multiple options, with the most meaningful being the following: If the domain size m is not a power of 2, polynomials are given as degree m-1-polynomials by their evaluations at g^0, ..., g^m-1; These evaluation points only form a subset of the larger set
g^0, ..., g^M-1, where M is the next power of 2 after M. FFTs operate in the larger space.
The C code tries to achieve this behaviour (well, maybe: While there are some next-power-of-2 calls and careful considerations that seem to achieve this, that case is never tested / documented / seriously considered or needed). 
My current plan to resolve the issue in the C code is to change to just reject non-powers of 2 and add some remarks in the code in order to keep it simple.

For your current Go code, you actually require / assume that the length of polys == Domain.Cardinality, so (different from the C case), the current Go implementation does not support the general case at the moment. For the sake of simplicity, I would suggest to just reject non-powers-of-two and keep things as they are, otherwise.

Note that this PR also includes some minor changes that are (also) part of a separate less-controversial PR to be finished later. These changes are just also included here to simplify rebasing / merging.