### PR TITLE
Change `findRootIndex` to use a an int64

### DIFF
--- a/internal/kzg/domain.go
+++ b/internal/kzg/domain.go
@@ -146,8 +146,8 @@ func (domain *Domain) ReverseRoots() {
 //
 //   - If point is in the domain (meaning that point is a domain.Cardinality'th root of unity), returns the index of the point in the domain.
 //   - If point is not in the domain, returns -1.
-func (domain *Domain) findRootIndex(point fr.Element) int {
-	for i := 0; i < int(domain.Cardinality); i++ {
+func (domain *Domain) findRootIndex(point fr.Element) int64 {
+	for i := int64(0); i < int64(domain.Cardinality); i++ {
 		if point.Equal(&domain.Roots[i]) {
 			return i
 		}
@@ -176,7 +176,7 @@ func (domain *Domain) EvaluateLagrangePolynomial(poly Polynomial, evalPoint fr.E
 //   - indexInDomain is the index inside domain.Roots, if evalPoint is among them, -1 otherwise
 //
 // This semantics was copied from the go library, see: https://cs.opensource.google/go/x/exp/+/522b1b58:slices/slices.go;l=117
-func (domain *Domain) evaluateLagrangePolynomial(poly Polynomial, evalPoint fr.Element) (evaluationResult *fr.Element, indexInDomain int, err error) {
+func (domain *Domain) evaluateLagrangePolynomial(poly Polynomial, evalPoint fr.Element) (evaluationResult *fr.Element, indexInDomain int64, err error) {
 	indexInDomain = -1
 
 	if domain.Cardinality != uint64(len(poly)) {

--- a/internal/kzg/domain_test.go
+++ b/internal/kzg/domain_test.go
@@ -110,7 +110,7 @@ func TestEvalPolynomialSmoke(t *testing.T) {
 
 	// Evaluate the lagrange polynomial at all points in the domain
 	//
-	for i := 0; i < int(domain.Cardinality); i++ {
+	for i := int64(0); i < int64(domain.Cardinality); i++ {
 		inputPoint := domain.Roots[i]
 
 		gotOutputPoint, indexInDomain, err := domain.evaluateLagrangePolynomial(lagrangePoly, inputPoint)

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -54,7 +54,7 @@ func Open(domain *Domain, p Polynomial, point fr.Element, ck *CommitKey) (Openin
 //
 // The matching code for this method is in `compute_kzg_proof_impl` where the quotient polynomial
 // is computed.
-func computeQuotientPoly(domain Domain, f Polynomial, indexInDomain int, fz, z fr.Element) ([]fr.Element, error) {
+func computeQuotientPoly(domain Domain, f Polynomial, indexInDomain int64, fz, z fr.Element) ([]fr.Element, error) {
 	if domain.Cardinality != uint64(len(f)) {
 		return nil, ErrPolynomialMismatchedSizeDomain
 	}

--- a/internal/kzg/kzg_prove.go
+++ b/internal/kzg/kzg_prove.go
@@ -55,7 +55,7 @@ func Open(domain *Domain, p Polynomial, evaluationPoint fr.Element, ck *CommitKe
 //
 // The matching code for this method is in `compute_kzg_proof_impl` where the quotient polynomial
 // is computed.
-func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int, fz, z fr.Element) ([]fr.Element, error) {
+func (domain *Domain) computeQuotientPoly(f Polynomial, indexInDomain int64, fz, z fr.Element) ([]fr.Element, error) {
 	if domain.Cardinality != uint64(len(f)) {
 		return nil, ErrPolynomialMismatchedSizeDomain
 	}


### PR DESCRIPTION
This PR changes some index variables from plain ints to uint64 / int64s.
The reason is that Domain.Cardinality can be up to 2^32, so signed indices could overflow if int is only 32 bits (the Go spec allows int to be either 32 or 64 bits).
Note that this also contains some other commits (duplicated in the other PRs) that would otherwise cause merge conflicts.
I fully expect (harmless) merge conflicts with #12 to happen anyway, so I guess #12 should be resolved first.